### PR TITLE
Document draft file upload multipart field

### DIFF
--- a/packages/backend/src/__snapshots__/createSwaggerDoc.spec.ts.snap
+++ b/packages/backend/src/__snapshots__/createSwaggerDoc.spec.ts.snap
@@ -1554,11 +1554,22 @@ Warning: if it is present, then badgehub clients on badges will not update the a
           "content": {
             "multipart/form-data": {
               "schema": {
-                "nullable": true,
+                "properties": {
+                  "file": {
+                    "description": "Draft file to upload. The multipart field name must be "file".",
+                    "format": "binary",
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "file",
+                ],
+                "type": "object",
               },
             },
           },
-          "description": "Body",
+          "description": "Multipart form data containing the draft file under the "file" field.",
+          "required": true,
         },
         "responses": {
           "204": {

--- a/packages/backend/src/createSwaggerDoc.ts
+++ b/packages/backend/src/createSwaggerDoc.ts
@@ -108,7 +108,7 @@ const draftFileUploadRequestBody = {
       },
     },
   },
-} as const;
+};
 
 function documentDraftFileUploadRequestBody(paths: PathsObject): PathsObject {
   const draftFileUploadPath = "/api/v3/projects/{slug}/draft/files/{filePath}";

--- a/packages/backend/src/createSwaggerDoc.ts
+++ b/packages/backend/src/createSwaggerDoc.ts
@@ -88,6 +88,48 @@ function removeEmptyBodiesFromPaths(paths: PathsObject) {
   );
 }
 
+const draftFileUploadRequestBody = {
+  description:
+    'Multipart form data containing the draft file under the "file" field.',
+  required: true,
+  content: {
+    "multipart/form-data": {
+      schema: {
+        type: "object",
+        required: ["file"],
+        properties: {
+          file: {
+            type: "string",
+            format: "binary",
+            description:
+              'Draft file to upload. The multipart field name must be "file".',
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+function documentDraftFileUploadRequestBody(paths: PathsObject): PathsObject {
+  const draftFileUploadPath = "/api/v3/projects/{slug}/draft/files/{filePath}";
+  const draftFileUploadPost = paths[draftFileUploadPath]?.post;
+
+  if (!draftFileUploadPost) {
+    return paths;
+  }
+
+  return {
+    ...paths,
+    [draftFileUploadPath]: {
+      ...paths[draftFileUploadPath],
+      post: {
+        ...draftFileUploadPost,
+        requestBody: draftFileUploadRequestBody,
+      },
+    },
+  };
+}
+
 export const createSwaggerDoc = () => {
   const apiDoc = { info: { title: "BadgeHub API", version: "1.0.0" } };
   const jsonSwagger = generateOpenApi(swaggerJsonContract, apiDoc, {
@@ -109,11 +151,13 @@ export const createSwaggerDoc = () => {
 
   return {
     ...jsonSwagger,
-    paths: removeEmptyBodiesFromPaths(
-      _.merge(
-        jsonSwagger.paths,
-        withPrefix("/api/v3", publicSwagger.paths),
-        withPrefix("/api/v3", privateSwagger.paths)
+    paths: documentDraftFileUploadRequestBody(
+      removeEmptyBodiesFromPaths(
+        _.merge(
+          jsonSwagger.paths,
+          withPrefix("/api/v3", publicSwagger.paths),
+          withPrefix("/api/v3", privateSwagger.paths)
+        )
       )
     ),
     tags: [


### PR DESCRIPTION
### Motivation
- The OpenAPI spec generated for the draft file upload endpoint did not document the required multipart field and its binary nature, causing unclear API docs for clients. 
- Ensure the published Swagger JSON explicitly describes the `file` multipart field so clients and generated docs are clear about the required upload format.

### Description
- Added a `draftFileUploadRequestBody` object that documents a required `file` multipart field of `format: binary`.
- Implemented `documentDraftFileUploadRequestBody(paths: PathsObject)` to inject the override for the `/api/v3/projects/{slug}/draft/files/{filePath}` `POST` operation.
- Applied `documentDraftFileUploadRequestBody` to the merged/cleaned paths inside `createSwaggerDoc` so the generated spec includes the multipart details. 
- Updated the Swagger snapshot `packages/backend/src/__snapshots__/createSwaggerDoc.spec.ts.snap` to reflect the new request body details.

### Testing
- Ran `npm run test --workspace=packages/backend -- createSwaggerDoc.spec.ts` which passed and updated the snapshot. 
- Ran the linter via `npm run lint -- packages/backend/src/createSwaggerDoc.ts packages/backend/src/__snapshots__/createSwaggerDoc.spec.ts.snap` which passed. 
- Ran `git diff --check` which reported no issues. 
- `npm run check:ts --workspace=packages/backend` did not complete within the 120s timeout in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a535b3bd99c832e9c225d32e90025e9)