### PR TITLE
Harden MIME type normalization

### DIFF
--- a/packages/backend/src/util/mimeTypeDetection.spec.ts
+++ b/packages/backend/src/util/mimeTypeDetection.spec.ts
@@ -64,6 +64,15 @@ describe("MIME Type Detection", () => {
       "audio/wave"
     );
   });
+
+  it("should treat generic browser MIME types case-insensitively and ignore parameters", () => {
+    expect(detectMimeType("Text/Plain; charset=utf-8", "icon.png")).toBe(
+      "image/png"
+    );
+    expect(detectMimeType("Application/X-Unknown", "style.css")).toBe(
+      "text/css"
+    );
+  });
 });
 
 describe("isSafeToRenderInline", () => {
@@ -72,6 +81,7 @@ describe("isSafeToRenderInline", () => {
     expect(isSafeToRenderInline("image/jpeg")).toBe(true);
     expect(isSafeToRenderInline("audio/wave")).toBe(true);
     expect(isSafeToRenderInline("audio/x-wav")).toBe(true);
+    expect(isSafeToRenderInline("Image/PNG; charset=binary")).toBe(true);
   });
 
   it("rejects SVG despite being an image type, since it can contain script", () => {

--- a/packages/backend/src/util/mimeTypeDetection.spec.ts
+++ b/packages/backend/src/util/mimeTypeDetection.spec.ts
@@ -48,6 +48,10 @@ describe("MIME Type Detection", () => {
 
   it("should handle empty or missing browser MIME type", () => {
     expect(detectMimeType("", "test.py")).toBe("text/x-python");
+    expect(detectMimeType(undefined, "test.py")).toBe("text/x-python");
+    expect(detectMimeType(null, "file.unknown")).toBe(
+      "application/octet-stream"
+    );
     expect(detectMimeType("", "file.unknown")).toBe("application/octet-stream");
   });
 

--- a/packages/backend/src/util/mimeTypeDetection.ts
+++ b/packages/backend/src/util/mimeTypeDetection.ts
@@ -29,8 +29,9 @@ export function detectMimeType(
   browserMimeType: string | undefined | null,
   filename: string
 ): string {
-  const normalizedBrowserMimeType = (browserMimeType || "")
-    .split(";")[0]
+  const normalizedBrowserMimeType = (
+    (browserMimeType || "").split(";")[0] ?? ""
+  )
     .trim()
     .toLowerCase();
 
@@ -81,7 +82,9 @@ export function isSafeToRenderInline(mimetype: string | undefined): boolean {
   if (!mimetype) {
     return false;
   }
-  const normalizedMimeType = mimetype.split(";")[0].trim().toLowerCase();
+  const normalizedMimeType = (mimetype.split(";")[0] ?? "")
+    .trim()
+    .toLowerCase();
   if (inlineUnsafeMimeTypes.has(normalizedMimeType)) {
     return false;
   }

--- a/packages/backend/src/util/mimeTypeDetection.ts
+++ b/packages/backend/src/util/mimeTypeDetection.ts
@@ -29,11 +29,17 @@ export function detectMimeType(
   browserMimeType: string,
   filename: string
 ): string {
+  const normalizedBrowserMimeType = browserMimeType
+    .split(";")[0]
+    .trim()
+    .toLowerCase();
+
   // If browser provided a specific, reliable MIME type, use it
   if (
     browserMimeType &&
-    !genericMimeTypes.has(browserMimeType) &&
-    !browserMimeType.startsWith("application/x-")
+    normalizedBrowserMimeType &&
+    !genericMimeTypes.has(normalizedBrowserMimeType) &&
+    !normalizedBrowserMimeType.startsWith("application/x-")
   ) {
     return browserMimeType;
   }
@@ -75,8 +81,12 @@ export function isSafeToRenderInline(mimetype: string | undefined): boolean {
   if (!mimetype) {
     return false;
   }
-  if (inlineUnsafeMimeTypes.has(mimetype)) {
+  const normalizedMimeType = mimetype.split(";")[0].trim().toLowerCase();
+  if (inlineUnsafeMimeTypes.has(normalizedMimeType)) {
     return false;
   }
-  return mimetype.startsWith("image/") || mimetype.startsWith("audio/");
+  return (
+    normalizedMimeType.startsWith("image/") ||
+    normalizedMimeType.startsWith("audio/")
+  );
 }

--- a/packages/backend/src/util/mimeTypeDetection.ts
+++ b/packages/backend/src/util/mimeTypeDetection.ts
@@ -26,10 +26,10 @@ const genericMimeTypes = new Set([
  * @returns The best-guess MIME type
  */
 export function detectMimeType(
-  browserMimeType: string,
+  browserMimeType: string | undefined | null,
   filename: string
 ): string {
-  const normalizedBrowserMimeType = browserMimeType
+  const normalizedBrowserMimeType = (browserMimeType || "")
     .split(";")[0]
     .trim()
     .toLowerCase();


### PR DESCRIPTION
### Motivation
- Browser-provided MIME types can include parameters or mixed casing (e.g. `Text/Plain; charset=utf-8`) which should not block extension-based fallback detection.
- Stored MIME types may also include parameters or casing that should be ignored for inline-render safety checks so images/audio continue to render inline correctly.

### Description
- Normalize the browser MIME type (split at `;`, `trim()`, `toLowerCase()`) before checking against `genericMimeTypes` and `application/x-` in `packages/backend/src/util/mimeTypeDetection.ts` while preserving the original value when returned.
- Normalize stored MIME types similarly in `isSafeToRenderInline` and use the normalized value for `inlineUnsafeMimeTypes` and `image/`/`audio/` prefix checks.
- Add unit tests in `packages/backend/src/util/mimeTypeDetection.spec.ts` that cover case-insensitive and parameterized browser MIME values and stored MIME types with parameters.

### Testing
- Ran `npm run test --workspace=packages/backend -- mimeTypeDetection.spec.ts` and the spec passed (12 tests).
- Ran `npm run build --workspace=packages/frontend` and the frontend build completed successfully (produced `dist/index.html`).
- Ran `npm run test --workspace=packages/backend -- public-rest.spec.ts` and it failed due to a local PostgreSQL connection refusal on port 5432 (tests require DB access).
- Ran `npm run check:ts --workspace=packages/backend` which was started in this environment but hung/was terminated before completion.
- Ran `npm run lint -- --staged?` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53d36649c0832ebebcf65a87812e31)