### PR TITLE
Prevent AppCard tag overflow

### DIFF
--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
@@ -136,45 +136,55 @@ const AppCard: React.FC<
         {/* Tags section pushed to bottom */}
         <div className="mt-auto mb-3">
           {(() => {
-            const MAX_VISIBLE_TAGS = 3;
-            const allTags = [
-              ...(categories?.map((cat, index) => ({
-                text: cat,
-                type: "category",
-                id: `category-${index}`,
-              })) ?? []),
-              ...(badges?.map((badge, index) => ({
-                text: badge,
-                type: "badge",
-                id: `badge-${index}`,
-              })) ?? []),
-            ];
-            const visibleTags = allTags.slice(0, MAX_VISIBLE_TAGS);
-            const hiddenCount = allTags.length - MAX_VISIBLE_TAGS;
+            const MAX_VISIBLE_CATEGORIES = 1;
+            const MAX_VISIBLE_BADGES = 1;
+            const categoryTags = categories ?? [];
+            const badgeTags = badges ?? [];
+            const hiddenCategoryCount = Math.max(
+              0,
+              categoryTags.length - MAX_VISIBLE_CATEGORIES
+            );
+            const hiddenBadgeCount = Math.max(
+              0,
+              badgeTags.length - MAX_VISIBLE_BADGES
+            );
 
             return (
               <>
-                {visibleTags.map((tag) => (
+                {categoryTags
+                  .slice(0, MAX_VISIBLE_CATEGORIES)
+                  .map((category) => (
+                    <span
+                      key={category}
+                      className="badge badge-neutral text-xs font-semibold mr-2"
+                    >
+                      {category}
+                    </span>
+                  ))}
+                {hiddenCategoryCount > 0 && (
                   <span
-                    key={tag.id}
-                    className={`${
-                      tag.type === "category"
-                        ? "badge badge-neutral"
-                        : "badge badge-success"
-                    } text-xs font-semibold mr-2`}
-                  >
-                    {tag.text}
-                  </span>
-                ))}
-                {hiddenCount > 0 && (
-                  <span
-                    className="text-xs opacity-50 font-medium cursor-help"
-                    title={allTags
-                      .slice(MAX_VISIBLE_TAGS)
-                      .map((tag) => tag.text)
+                    className="text-xs opacity-50 font-medium cursor-help mr-2"
+                    title={categoryTags
+                      .slice(MAX_VISIBLE_CATEGORIES)
                       .join(", ")}
                   >
-                    +{hiddenCount} more
+                    +{hiddenCategoryCount}
+                  </span>
+                )}
+                {badgeTags.slice(0, MAX_VISIBLE_BADGES).map((badge) => (
+                  <span
+                    key={badge}
+                    className="badge badge-success text-xs font-semibold mr-2"
+                  >
+                    {badge}
+                  </span>
+                ))}
+                {hiddenBadgeCount > 0 && (
+                  <span
+                    className="text-xs opacity-50 font-medium cursor-help"
+                    title={badgeTags.slice(MAX_VISIBLE_BADGES).join(", ")}
+                  >
+                    +{hiddenBadgeCount}
                   </span>
                 )}
               </>

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
@@ -1,6 +1,6 @@
 import { ERROR_ICON_URL, FALLBACK_ICON_URL } from "@config.ts";
-import { DownloadIcon } from "@sharedComponents/AppsGrid/DownloadIcon.tsx";
 import AppCardTags from "@sharedComponents/AppsGrid/AppCardTags.tsx";
+import { DownloadIcon } from "@sharedComponents/AppsGrid/DownloadIcon.tsx";
 import GitLink from "@sharedComponents/GitLink.tsx";
 import { useSession } from "@sharedComponents/keycloakSession/SessionContext.tsx";
 import { MLink } from "@sharedComponents/MLink.tsx";

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
@@ -1,5 +1,6 @@
 import { ERROR_ICON_URL, FALLBACK_ICON_URL } from "@config.ts";
 import { DownloadIcon } from "@sharedComponents/AppsGrid/DownloadIcon.tsx";
+import AppCardTags from "@sharedComponents/AppsGrid/AppCardTags.tsx";
 import GitLink from "@sharedComponents/GitLink.tsx";
 import { useSession } from "@sharedComponents/keycloakSession/SessionContext.tsx";
 import { MLink } from "@sharedComponents/MLink.tsx";
@@ -133,64 +134,7 @@ const AppCard: React.FC<
           {description}
         </p>
 
-        {/* Tags section pushed to bottom */}
-        <div className="mt-auto mb-3">
-          {(() => {
-            const MAX_VISIBLE_CATEGORIES = 1;
-            const MAX_VISIBLE_BADGES = 1;
-            const categoryTags = categories ?? [];
-            const badgeTags = badges ?? [];
-            const hiddenCategoryCount = Math.max(
-              0,
-              categoryTags.length - MAX_VISIBLE_CATEGORIES
-            );
-            const hiddenBadgeCount = Math.max(
-              0,
-              badgeTags.length - MAX_VISIBLE_BADGES
-            );
-
-            return (
-              <>
-                {categoryTags
-                  .slice(0, MAX_VISIBLE_CATEGORIES)
-                  .map((category) => (
-                    <span
-                      key={category}
-                      className="badge badge-neutral text-xs font-semibold mr-2"
-                    >
-                      {category}
-                    </span>
-                  ))}
-                {hiddenCategoryCount > 0 && (
-                  <span
-                    className="text-xs opacity-50 font-medium cursor-help mr-2"
-                    title={categoryTags
-                      .slice(MAX_VISIBLE_CATEGORIES)
-                      .join(", ")}
-                  >
-                    +{hiddenCategoryCount}
-                  </span>
-                )}
-                {badgeTags.slice(0, MAX_VISIBLE_BADGES).map((badge) => (
-                  <span
-                    key={badge}
-                    className="badge badge-success text-xs font-semibold mr-2"
-                  >
-                    {badge}
-                  </span>
-                ))}
-                {hiddenBadgeCount > 0 && (
-                  <span
-                    className="text-xs opacity-50 font-medium cursor-help"
-                    title={badgeTags.slice(MAX_VISIBLE_BADGES).join(", ")}
-                  >
-                    +{hiddenBadgeCount}
-                  </span>
-                )}
-              </>
-            );
-          })()}
-        </div>
+        <AppCardTags categories={categories} badges={badges} />
       </div>
 
       {/* Footer with stats */}

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCardTags.test.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCardTags.test.tsx
@@ -38,4 +38,10 @@ describe("AppCardTags", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/more categories/i)).not.toBeInTheDocument();
   });
+
+  it("handles null tag arrays without rendering groups", () => {
+    render(<AppCardTags categories={null} badges={null} />);
+
+    expect(screen.queryByRole("group")).not.toBeInTheDocument();
+  });
 });

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCardTags.test.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCardTags.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import AppCardTags from "./AppCardTags.tsx";
+
+describe("AppCardTags", () => {
+  it("shows one bounded tag and an explicit overflow count per group", () => {
+    render(
+      <AppCardTags
+        categories={["A very long category name", "Games", "Utilities"]}
+        badges={["why2025", "mch2022"]}
+      />
+    );
+
+    const categories = screen.getByRole("group", { name: "Categories" });
+    const badges = screen.getByRole("group", { name: "Badges" });
+
+    expect(
+      within(categories).getByText("A very long category name")
+    ).toHaveClass("truncate");
+    expect(within(categories).queryByText("Games")).not.toBeInTheDocument();
+    expect(
+      within(categories).getByLabelText("2 more categories: Games, Utilities")
+    ).toHaveTextContent("+2");
+    expect(within(badges).getByTitle("why2025")).toHaveTextContent("why2025");
+    expect(
+      within(badges).getByLabelText("1 more badge: mch2022")
+    ).toHaveTextContent("+1");
+  });
+
+  it("omits empty groups and overflow counts for single values", () => {
+    render(<AppCardTags categories={["Games"]} badges={undefined} />);
+
+    expect(
+      screen.getByRole("group", { name: "Categories" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("group", { name: "Badges" })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/more categories/i)).not.toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCardTags.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCardTags.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type React from "react";
 
 const MAX_VISIBLE_TAGS_PER_GROUP = 1;
 
@@ -15,14 +15,13 @@ const TagGroup: React.FC<{
   const hiddenLabel = hiddenTags.join(", ");
 
   return (
-    <div
-      role="group"
+    <fieldset
       aria-label={label}
-      className="flex min-w-0 flex-1 items-center gap-1.5"
+      className="m-0 flex min-w-0 flex-1 items-center gap-1.5 border-0 p-0"
     >
-      {visibleTags.map((tag, index) => (
+      {visibleTags.map((tag) => (
         <span
-          key={`${tag}-${index}`}
+          key={tag}
           className={`${badgeClassName} min-w-0 text-xs font-semibold`}
           title={tag}
         >
@@ -30,7 +29,7 @@ const TagGroup: React.FC<{
         </span>
       ))}
       {hiddenTags.length > 0 && (
-        <span
+        <output
           className="shrink-0 cursor-help text-xs font-medium opacity-60"
           aria-label={`${hiddenTags.length} more ${
             hiddenTags.length === 1 ? singularLabel : label.toLowerCase()
@@ -38,9 +37,9 @@ const TagGroup: React.FC<{
           title={`More ${label.toLowerCase()}: ${hiddenLabel}`}
         >
           +{hiddenTags.length}
-        </span>
+        </output>
       )}
-    </div>
+    </fieldset>
   );
 };
 

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCardTags.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCardTags.tsx
@@ -23,7 +23,7 @@ const TagGroup: React.FC<{
       {visibleTags.map((tag, index) => (
         <span
           key={`${tag}-${index}`}
-          className={`${badgeClassName} min-w-0 flex-1 text-xs font-semibold`}
+          className={`${badgeClassName} min-w-0 text-xs font-semibold`}
           title={tag}
         >
           <span className="truncate">{tag}</span>
@@ -45,23 +45,28 @@ const TagGroup: React.FC<{
 };
 
 const AppCardTags: React.FC<{
-  categories: readonly string[] | undefined;
-  badges: readonly string[] | undefined;
-}> = ({ categories = [], badges = [] }) => (
-  <div className="mt-auto mb-3 flex w-full min-w-0 items-center gap-2">
-    <TagGroup
-      label="Categories"
-      singularLabel="category"
-      tags={categories}
-      badgeClassName="badge badge-neutral"
-    />
-    <TagGroup
-      label="Badges"
-      singularLabel="badge"
-      tags={badges}
-      badgeClassName="badge badge-success"
-    />
-  </div>
-);
+  categories: readonly string[] | null | undefined;
+  badges: readonly string[] | null | undefined;
+}> = ({ categories, badges }) => {
+  const safeCategories = categories ?? [];
+  const safeBadges = badges ?? [];
+
+  return (
+    <div className="mt-auto mb-3 flex w-full min-w-0 items-center gap-2">
+      <TagGroup
+        label="Categories"
+        singularLabel="category"
+        tags={safeCategories}
+        badgeClassName="badge badge-neutral"
+      />
+      <TagGroup
+        label="Badges"
+        singularLabel="badge"
+        tags={safeBadges}
+        badgeClassName="badge badge-success"
+      />
+    </div>
+  );
+};
 
 export default AppCardTags;

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCardTags.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCardTags.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+
+const MAX_VISIBLE_TAGS_PER_GROUP = 1;
+
+const TagGroup: React.FC<{
+  label: string;
+  singularLabel: string;
+  tags: readonly string[];
+  badgeClassName: string;
+}> = ({ label, singularLabel, tags, badgeClassName }) => {
+  if (tags.length === 0) return null;
+
+  const visibleTags = tags.slice(0, MAX_VISIBLE_TAGS_PER_GROUP);
+  const hiddenTags = tags.slice(MAX_VISIBLE_TAGS_PER_GROUP);
+  const hiddenLabel = hiddenTags.join(", ");
+
+  return (
+    <div
+      role="group"
+      aria-label={label}
+      className="flex min-w-0 flex-1 items-center gap-1.5"
+    >
+      {visibleTags.map((tag, index) => (
+        <span
+          key={`${tag}-${index}`}
+          className={`${badgeClassName} min-w-0 flex-1 text-xs font-semibold`}
+          title={tag}
+        >
+          <span className="truncate">{tag}</span>
+        </span>
+      ))}
+      {hiddenTags.length > 0 && (
+        <span
+          className="shrink-0 cursor-help text-xs font-medium opacity-60"
+          aria-label={`${hiddenTags.length} more ${
+            hiddenTags.length === 1 ? singularLabel : label.toLowerCase()
+          }: ${hiddenLabel}`}
+          title={`More ${label.toLowerCase()}: ${hiddenLabel}`}
+        >
+          +{hiddenTags.length}
+        </span>
+      )}
+    </div>
+  );
+};
+
+const AppCardTags: React.FC<{
+  categories: readonly string[] | undefined;
+  badges: readonly string[] | undefined;
+}> = ({ categories = [], badges = [] }) => (
+  <div className="mt-auto mb-3 flex w-full min-w-0 items-center gap-2">
+    <TagGroup
+      label="Categories"
+      singularLabel="category"
+      tags={categories}
+      badgeClassName="badge badge-neutral"
+    />
+    <TagGroup
+      label="Badges"
+      singularLabel="badge"
+      tags={badges}
+      badgeClassName="badge badge-success"
+    />
+  </div>
+);
+
+export default AppCardTags;


### PR DESCRIPTION
## Summary

- extract category and badge rendering into a focused `AppCardTags` component
- constrain both tag groups so long labels truncate instead of expanding the card
- retain complete visible labels in tooltips
- add separate, descriptive overflow counters for hidden categories and badges
- handle both `null` and `undefined` optional tag arrays safely
- add direct tests for layout and accessibility semantics

## Why

The previous card implementation could overflow with long or numerous tags. A combined count also made it unclear which kind of values were hidden, especially for assistive-technology users.

## Impact

Cards remain stable with arbitrary tag lengths, while users can still discover every hidden value.

## Validation

- frontend test suite: 66 passed, 1 skipped
- focused backend API suite: 43 passed
- frontend and backend TypeScript checks
- changed-file ESLint checks
- frontend production build

Closes #14
